### PR TITLE
Update ignore globs

### DIFF
--- a/box.json
+++ b/box.json
@@ -48,5 +48,13 @@
     "installPaths":{
         "testbox":"testbox/"
     },
-    "ignore":[]
+    "ignore":[
+        "**/.*",
+        "test",
+        "tests",
+        ".engine",
+        ".travis.yml",
+        ".gitignore",
+        "server.json"
+    ]
 }


### PR DESCRIPTION
This prevents things like the `.git` folder from being installed.