### PR TITLE
Add ignore to box.json

### DIFF
--- a/box.json
+++ b/box.json
@@ -48,5 +48,10 @@
     "installPaths":{
         "testbox":"testbox/"
     },
-    "ignore":[]
+    "ignore":[
+      "**/.*",
+      "test",
+      "tests",
+      "travis.yml"
+    ]
 }


### PR DESCRIPTION
Whenever this package gets installed, it brings along .gitignore, travis.yml, and the tests folder. 

This PR causes forgebox to ignore those files. 
