### PR TITLE
Remove max rows limit.

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -2,18 +2,11 @@ component {
 
 	this.title = "Paginator";
 	this.author = "Javier Quintero";
-	this.webURL  = "https://www.ortussolutions.com";
+	this.webURL = "https://www.ortussolutions.com";
 	this.description = "This module builds the pagination struct for API responses and custom data tables.";
 	this.cfmapping = "cbpaginator";
 	this.dependencies = [];
 
-	function configure() {
-		settings = {
-			"defaults": {
-				"maxRows": 25,
-				"maxRowsLimit": 200
-			}
-		};
-	}
+	function configure() {}
 
 }

--- a/models/Pagination.cfc
+++ b/models/Pagination.cfc
@@ -3,17 +3,6 @@
  */
 component singleton accessors="true" {
 
-    property name="settings" inject="coldbox:moduleSettings:cbpaginator";
-
-    /**
-     * Creates a new paginator
-     * If using this in ColdBox, these settings will be overridden by WireBox
-     */
-    function init( struct settings = getDefaultSettings() ) {
-        variables.settings = arguments.settings;
-        return this;
-    }
-
     /**
      * Generates a pagination struct
      *
@@ -26,11 +15,11 @@ component singleton accessors="true" {
     public struct function generate(
         numeric totalRecords = 0,
         numeric page = 1,
-        numeric maxRows = settings.defaults.maxRows
+        numeric maxRows = 25
     ) {
         var pagination = {};
         pagination[ "totalRecords" ] = arguments.totalRecords;
-        pagination[ "maxRows" ] = clamp( 0, arguments.maxRows, settings.defaults.maxRowsLimit );
+        pagination[ "maxRows" ] = max( 0, arguments.maxRows );
         pagination[ "totalPages" ] = pagination.maxRows != 0 ? ceiling( pagination.totalRecords / pagination.maxRows ) : 0;
         pagination[ "page" ] = clamp( 1, arguments.page, pagination.totalPages );
         pagination[ "offset" ] = ( pagination.page - 1 ) * pagination.maxRows;
@@ -54,7 +43,7 @@ component singleton accessors="true" {
         numeric totalRecords = 0,
         array results = [],
         numeric page = 1,
-        numeric maxRows = settings.defaults.maxRows,
+        numeric maxRows = 25,
         boolean asResultsMap = false,
         string keyName = "id",
         string resultsKeyName = "results"
@@ -96,15 +85,6 @@ component singleton accessors="true" {
 
             return acc;
         }, { "#resultsKeyName#" = [], "#resultsMapKeyName#" = {} } );
-    }
-
-    private struct function getDefaultSettings() {
-        return {
-            "defaults": {
-                "maxRows": 25,
-                "maxRowsLimit": 200
-            }
-        };
     }
 
 }

--- a/tests/specs/PaginationSpec.cfc
+++ b/tests/specs/PaginationSpec.cfc
@@ -44,21 +44,6 @@ component extends="testbox.system.BaseSpec" {
                         "totalRecords": 100
                     } );
                 } );
-
-                it( "can caps the maxrows with the maxRowsLimit", function() {
-                    var settings = getSettings();
-                    settings.defaults.maxRowsLimit = 10;
-                    var paginator = createMock( "models.Pagination" );
-                    paginator.$property( propertyName = "settings", mock = settings );
-                    var result = paginator.generate( 100, 3, 25 );
-                    expect( result ).toBe( {
-                        "maxRows": 10,
-                        "offset": 20,
-                        "page": 3,
-                        "totalPages": 10,
-                        "totalRecords": 100
-                    } );
-                } );
             } );
 
             describe( "generateWithResults", function() {
@@ -109,25 +94,6 @@ component extends="testbox.system.BaseSpec" {
                             "maxRows": 10,
                             "offset": 10,
                             "page": 2,
-                            "totalPages": 10,
-                            "totalRecords": 100
-                        },
-                        "results": mockResults
-                    } );
-                } );
-
-                it( "can caps the maxrows with the maxRowsLimit", function() {
-                    var settings = getSettings();
-                    settings.defaults.maxRowsLimit = 10;
-                    var paginator = createMock( "models.Pagination" );
-                    paginator.$property( propertyName = "settings", mock = settings );
-                    var mockResults = [ { "id": 1 }, { "id": 2 }, { "id": 3 } ];
-                    var result = paginator.generateWithResults( 100, mockResults, 3, 25 );
-                    expect( result ).toBe( {
-                        "pagination": {
-                            "maxRows": 10,
-                            "offset": 20,
-                            "page": 3,
                             "totalPages": 10,
                             "totalRecords": 100
                         },


### PR DESCRIPTION
As per our discussions on the Ortus team, this library would be better
served by only generating the pagination struct, not by changing the
max rows values.