### PR TITLE
Add simple paginate endpoint which doesn't expect a count

### DIFF
--- a/models/Pagination.cfc
+++ b/models/Pagination.cfc
@@ -63,6 +63,64 @@ component singleton accessors="true" {
         return response;
     }
 
+    /**
+     * Generates a simple pagination struct.
+     *
+     * @hasMore Boolean flag if there are more results
+     * @page page number (current page)
+     * @maxRows Maximum number of rows displayed per page
+     *
+     * @returns struct -> { "hasMore" : boolean, "maxRows" : numeric, "offset" : numeric, "page" : numeric }
+     */
+    public struct function generateSimple(
+        required boolean hasMore,
+        numeric page = 1,
+        numeric maxRows = 25
+    ) {
+        var pagination = {};
+        pagination[ "maxRows" ] = max( 0, arguments.maxRows );
+        pagination[ "page" ] = arguments.page;
+        pagination[ "offset" ] = ( pagination.page - 1 ) * pagination.maxRows;
+        pagination[ "hasMore" ] = arguments.hasMore;
+        return pagination;
+    }
+
+    /**
+     * Generates the simple pagination struct along with the results
+     *
+     * @results List with the results ta will be included in the response
+     * @page page number (current page)
+     * @maxRows Maximum number of rows displayed per page
+     * @resultMap Flag to determine if we want a result map for the results
+     * @keyName Name of the key to find in each record for a results map
+     * @resultsKeyName Results key name to associate to the response
+     *
+     * @returns struct -> { "pagination" : {}, "results" : "[] }
+     */
+    public struct function generateSimpleWithResults(
+        array results = [],
+        numeric page = 1,
+        numeric maxRows = 25,
+        boolean asResultsMap = false,
+        string keyName = "id",
+        string resultsKeyName = "results"
+    ) {
+        var response = {};
+        response[ "pagination" ] = generateSimple(
+            arguments.results.len() > arguments.maxRows,
+            arguments.page,
+            arguments.maxRows
+        );
+        arguments.results = arguments.results.slice( 1, min( arguments.results.len(), arguments.maxRows ) );
+        structAppend(
+            response,
+            arguments.asResultsMap ?
+                generateResultsMap( arguments.results, arguments.keyName, arguments.resultsKeyName ) :
+                { "#arguments.resultsKeyName#" = arguments.results }
+        );
+        return response;
+    }
+
     private numeric function clamp( lowerLimit, result, upperLimit ) {
         arguments.result = ceiling( arguments.result );
         arguments.result = min( arguments.result, arguments.upperLimit );

--- a/tests/specs/PaginationSpec.cfc
+++ b/tests/specs/PaginationSpec.cfc
@@ -2,176 +2,344 @@ component extends="testbox.system.BaseSpec" {
 
 	function run() {
 		describe( "paginator", function() {
-            describe( "generate", function() {
-                it( "it can generate pagination with defaults", function() {
-                    var settings = getSettings();
-                    var paginator = createMock( "models.Pagination" );
-                    paginator.$property( propertyName = "settings", mock = settings );
-                    var result = paginator.generate( 100 );
-                    expect( result ).toBe( {
-                        "maxRows": 25,
-                        "offset": 0,
-                        "page": 1,
-                        "totalPages": 4,
-                        "totalRecords": 100
-                    } );
-                } );
-
-                it( "can generate pagination for a different page", function() {
-                    var settings = getSettings();
-                    var paginator = createMock( "models.Pagination" );
-                    paginator.$property( propertyName = "settings", mock = settings );
-                    var result = paginator.generate( 100, 2 );
-                    expect( result ).toBe( {
-                        "maxRows": 25,
-                        "offset": 25,
-                        "page": 2,
-                        "totalPages": 4,
-                        "totalRecords": 100
-                    } );
-                } );
-
-                it( "can generate pagination with a custom maxRows", function() {
-                    var settings = getSettings();
-                    var paginator = createMock( "models.Pagination" );
-                    paginator.$property( propertyName = "settings", mock = settings );
-                    var result = paginator.generate( 100, 2, 10 );
-                    expect( result ).toBe( {
-                        "maxRows": 10,
-                        "offset": 10,
-                        "page": 2,
-                        "totalPages": 10,
-                        "totalRecords": 100
-                    } );
-                } );
-            } );
-
-            describe( "generateWithResults", function() {
-                it( "it can generate pagination with defaults", function() {
-                    var settings = getSettings();
-                    var paginator = createMock( "models.Pagination" );
-                    paginator.$property( propertyName = "settings", mock = settings );
-                    var mockResults = [ { "id": 1 }, { "id": 2 }, { "id": 3 } ];
-                    var result = paginator.generateWithResults( 100, mockResults );
-                    expect( result ).toBe( {
-                        "pagination": {
+            describe( "length-aware pagination", function() {
+                describe( "generate", function() {
+                    it( "it can generate pagination with defaults", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var result = paginator.generate( 100 );
+                        expect( result ).toBe( {
                             "maxRows": 25,
                             "offset": 0,
                             "page": 1,
                             "totalPages": 4,
                             "totalRecords": 100
-                        },
-                        "results": mockResults
+                        } );
                     } );
-                } );
-
-                it( "can generate pagination for a different page", function() {
-                    var settings = getSettings();
-                    var paginator = createMock( "models.Pagination" );
-                    paginator.$property( propertyName = "settings", mock = settings );
-                    var mockResults = [ { "id": 1 }, { "id": 2 }, { "id": 3 } ];
-                    var result = paginator.generateWithResults( 100, mockResults, 2 );
-                    expect( result ).toBe( {
-                        "pagination": {
+    
+                    it( "can generate pagination for a different page", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var result = paginator.generate( 100, 2 );
+                        expect( result ).toBe( {
                             "maxRows": 25,
                             "offset": 25,
                             "page": 2,
                             "totalPages": 4,
                             "totalRecords": 100
-                        },
-                        "results": mockResults
+                        } );
                     } );
-                } );
-
-                it( "can generate pagination with a custom maxRows", function() {
-                    var settings = getSettings();
-                    var paginator = createMock( "models.Pagination" );
-                    paginator.$property( propertyName = "settings", mock = settings );
-                    var mockResults = [ { "id": 1 }, { "id": 2 }, { "id": 3 } ];
-                    var result = paginator.generateWithResults( 100, mockResults, 2, 10 );
-                    expect( result ).toBe( {
-                        "pagination": {
+    
+                    it( "can generate pagination with a custom maxRows", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var result = paginator.generate( 100, 2, 10 );
+                        expect( result ).toBe( {
                             "maxRows": 10,
                             "offset": 10,
                             "page": 2,
                             "totalPages": 10,
                             "totalRecords": 100
-                        },
-                        "results": mockResults
+                        } );
                     } );
                 } );
-
-                it( "can create a results map instead of an array for results", function() {
-                    var settings = getSettings();
-                    var paginator = createMock( "models.Pagination" );
-                    paginator.$property( propertyName = "settings", mock = settings );
-                    var mockResults = [ { "id": 1 }, { "id": 2 }, { "id": 3 } ];
-                    var result = paginator.generateWithResults( 100, mockResults, 3, 25, true );
-                    expect( result ).toBe( {
-                        "pagination": {
+    
+                describe( "generateWithResults", function() {
+                    it( "it can generate pagination with defaults", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "id": 1 }, { "id": 2 }, { "id": 3 } ];
+                        var result = paginator.generateWithResults( 100, mockResults );
+                        expect( result ).toBe( {
+                            "pagination": {
+                                "maxRows": 25,
+                                "offset": 0,
+                                "page": 1,
+                                "totalPages": 4,
+                                "totalRecords": 100
+                            },
+                            "results": mockResults
+                        } );
+                    } );
+    
+                    it( "can generate pagination for a different page", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "id": 1 }, { "id": 2 }, { "id": 3 } ];
+                        var result = paginator.generateWithResults( 100, mockResults, 2 );
+                        expect( result ).toBe( {
+                            "pagination": {
+                                "maxRows": 25,
+                                "offset": 25,
+                                "page": 2,
+                                "totalPages": 4,
+                                "totalRecords": 100
+                            },
+                            "results": mockResults
+                        } );
+                    } );
+    
+                    it( "can generate pagination with a custom maxRows", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "id": 1 }, { "id": 2 }, { "id": 3 } ];
+                        var result = paginator.generateWithResults( 100, mockResults, 2, 10 );
+                        expect( result ).toBe( {
+                            "pagination": {
+                                "maxRows": 10,
+                                "offset": 10,
+                                "page": 2,
+                                "totalPages": 10,
+                                "totalRecords": 100
+                            },
+                            "results": mockResults
+                        } );
+                    } );
+    
+                    it( "can create a results map instead of an array for results", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "id": 1 }, { "id": 2 }, { "id": 3 } ];
+                        var result = paginator.generateWithResults( 100, mockResults, 3, 25, true );
+                        expect( result ).toBe( {
+                            "pagination": {
+                                "maxRows": 25,
+                                "offset": 50,
+                                "page": 3,
+                                "totalPages": 4,
+                                "totalRecords": 100
+                            },
+                            "results": [ 1, 2, 3 ],
+                            "resultsMap": { "1": { "id": 1 }, "2": { "id": 2 }, "3": { "id": 3 } }
+                        } );
+                    } );
+    
+                    it( "can use a custom keyName when generating the resultsMap", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "myId": 1 }, { "myId": 2 }, { "myId": 3 } ];
+                        var result = paginator.generateWithResults( 100, mockResults, 3, 25, true, "myId" );
+                        expect( result ).toBe( {
+                            "pagination": {
+                                "maxRows": 25,
+                                "offset": 50,
+                                "page": 3,
+                                "totalPages": 4,
+                                "totalRecords": 100
+                            },
+                            "results": [ 1, 2, 3 ],
+                            "resultsMap": { "1": { "myId": 1 }, "2": { "myId": 2 }, "3": { "myId": 3 } }
+                        } );
+                    } );
+    
+                    it( "can use a resultsKeyName when generating the resultsMap", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "myId": 1 }, { "myId": 2 }, { "myId": 3 } ];
+                        var result = paginator.generateWithResults( 100, mockResults, 3, 25, true, "myId", "stuff" );
+                        expect( result ).toBe( {
+                            "pagination": {
+                                "maxRows": 25,
+                                "offset": 50,
+                                "page": 3,
+                                "totalPages": 4,
+                                "totalRecords": 100
+                            },
+                            "stuff": [ 1, 2, 3 ],
+                            "stuffMap": { "1": { "myId": 1 }, "2": { "myId": 2 }, "3": { "myId": 3 } }
+                        } );
+                    } );
+    
+                    it( "can call getters when generating the resultsMap", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "getId": function() { return 1; } }, { "getId": function() { return 2; } }, { "getId": function() { return 3; } } ];
+                        var result = paginator.generateWithResults( 100, mockResults, 3, 25, true );
+                        expect( result.pagination ).toBe( {
                             "maxRows": 25,
                             "offset": 50,
                             "page": 3,
                             "totalPages": 4,
                             "totalRecords": 100
-                        },
-                        "results": [ 1, 2, 3 ],
-                        "resultsMap": { "1": { "id": 1 }, "2": { "id": 2 }, "3": { "id": 3 } }
+                        } );
+                        expect( result.results ).toBe( [ 1, 2, 3 ] );
+                    } );
+                } );
+            } );
+
+            describe( "simple pagination", function() {
+                describe( "generateSimple", function() {
+                    it( "it can generate pagination with defaults", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var result = paginator.generateSimple( true );
+                        expect( result ).toBe( {
+                            "maxRows": 25,
+                            "offset": 0,
+                            "page": 1,
+                            "hasMore": true
+                        } );
+                    } );
+    
+                    it( "can generate pagination for a different page", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var result = paginator.generateSimple( false, 2 );
+                        expect( result ).toBe( {
+                            "maxRows": 25,
+                            "offset": 25,
+                            "page": 2,
+                            "hasMore": false
+                        } );
+                    } );
+    
+                    it( "can generate pagination with a custom maxRows", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var result = paginator.generateSimple( true, 2, 10 );
+                        expect( result ).toBe( {
+                            "maxRows": 10,
+                            "offset": 10,
+                            "page": 2,
+                            "hasMore": true
+                        } );
                     } );
                 } );
 
-                it( "can use a custom keyName when generating the resultsMap", function() {
-                    var settings = getSettings();
-                    var paginator = createMock( "models.Pagination" );
-                    paginator.$property( propertyName = "settings", mock = settings );
-                    var mockResults = [ { "myId": 1 }, { "myId": 2 }, { "myId": 3 } ];
-                    var result = paginator.generateWithResults( 100, mockResults, 3, 25, true, "myId" );
-                    expect( result ).toBe( {
-                        "pagination": {
+                describe( "generateSimpleWithResults", function() {
+                    it( "it can generate pagination with defaults", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "id": 1 }, { "id": 2 }, { "id": 3 } ];
+                        var result = paginator.generateSimpleWithResults( mockResults );
+                        expect( result ).toBe( {
+                            "pagination": {
+                                "maxRows": 25,
+                                "offset": 0,
+                                "page": 1,
+                                "hasMore": false
+                            },
+                            "results": mockResults
+                        } );
+                    } );
+    
+                    it( "can generate pagination for a different page", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "id": 1 }, { "id": 2 }, { "id": 3 } ];
+                        var result = paginator.generateSimpleWithResults( mockResults, 2 );
+                        expect( result ).toBe( {
+                            "pagination": {
+                                "maxRows": 25,
+                                "offset": 25,
+                                "page": 2,
+                                "hasMore": false
+                            },
+                            "results": mockResults
+                        } );
+                    } );
+    
+                    it( "can generate pagination with a custom maxRows", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "id": 1 }, { "id": 2 }, { "id": 3 } ];
+                        var maxRows = 2;
+                        var result = paginator.generateSimpleWithResults( mockResults, 1, maxRows );
+                        expect( result ).toBe( {
+                            "pagination": {
+                                "maxRows": 2,
+                                "offset": 0,
+                                "page": 1,
+                                "hasMore": true
+                            },
+                            "results": mockResults.slice( 1, maxRows )
+                        } );
+                    } );
+    
+                    it( "can create a results map instead of an array for results", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "id": 1 }, { "id": 2 }, { "id": 3 } ];
+                        var result = paginator.generateSimpleWithResults( mockResults, 3, 25, true );
+                        expect( result ).toBe( {
+                            "pagination": {
+                                "maxRows": 25,
+                                "offset": 50,
+                                "page": 3,
+                                "hasMore": false
+                            },
+                            "results": [ 1, 2, 3 ],
+                            "resultsMap": { "1": { "id": 1 }, "2": { "id": 2 }, "3": { "id": 3 } }
+                        } );
+                    } );
+    
+                    it( "can use a custom keyName when generating the resultsMap", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "myId": 1 }, { "myId": 2 }, { "myId": 3 } ];
+                        var result = paginator.generateSimpleWithResults( mockResults, 3, 25, true, "myId" );
+                        expect( result ).toBe( {
+                            "pagination": {
+                                "maxRows": 25,
+                                "offset": 50,
+                                "page": 3,
+                                "hasMore": false
+                            },
+                            "results": [ 1, 2, 3 ],
+                            "resultsMap": { "1": { "myId": 1 }, "2": { "myId": 2 }, "3": { "myId": 3 } }
+                        } );
+                    } );
+    
+                    it( "can use a resultsKeyName when generating the resultsMap", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "myId": 1 }, { "myId": 2 }, { "myId": 3 } ];
+                        var result = paginator.generateSimpleWithResults( mockResults, 3, 25, true, "myId", "stuff" );
+                        expect( result ).toBe( {
+                            "pagination": {
+                                "maxRows": 25,
+                                "offset": 50,
+                                "page": 3,
+                                "hasMore": false
+                            },
+                            "stuff": [ 1, 2, 3 ],
+                            "stuffMap": { "1": { "myId": 1 }, "2": { "myId": 2 }, "3": { "myId": 3 } }
+                        } );
+                    } );
+    
+                    it( "can call getters when generating the resultsMap", function() {
+                        var settings = getSettings();
+                        var paginator = createMock( "models.Pagination" );
+                        paginator.$property( propertyName = "settings", mock = settings );
+                        var mockResults = [ { "getId": function() { return 1; } }, { "getId": function() { return 2; } }, { "getId": function() { return 3; } } ];
+                        var result = paginator.generateSimpleWithResults( mockResults, 3, 25, true );
+                        expect( result.pagination ).toBe( {
                             "maxRows": 25,
                             "offset": 50,
                             "page": 3,
-                            "totalPages": 4,
-                            "totalRecords": 100
-                        },
-                        "results": [ 1, 2, 3 ],
-                        "resultsMap": { "1": { "myId": 1 }, "2": { "myId": 2 }, "3": { "myId": 3 } }
+                            "hasMore": false
+                        } );
+                        expect( result.results ).toBe( [ 1, 2, 3 ] );
                     } );
-                } );
-
-                it( "can use a resultsKeyName when generating the resultsMap", function() {
-                    var settings = getSettings();
-                    var paginator = createMock( "models.Pagination" );
-                    paginator.$property( propertyName = "settings", mock = settings );
-                    var mockResults = [ { "myId": 1 }, { "myId": 2 }, { "myId": 3 } ];
-                    var result = paginator.generateWithResults( 100, mockResults, 3, 25, true, "myId", "stuff" );
-                    expect( result ).toBe( {
-                        "pagination": {
-                            "maxRows": 25,
-                            "offset": 50,
-                            "page": 3,
-                            "totalPages": 4,
-                            "totalRecords": 100
-                        },
-                        "stuff": [ 1, 2, 3 ],
-                        "stuffMap": { "1": { "myId": 1 }, "2": { "myId": 2 }, "3": { "myId": 3 } }
-                    } );
-                } );
-
-                it( "can call getters when generating the resultsMap", function() {
-                    var settings = getSettings();
-                    var paginator = createMock( "models.Pagination" );
-                    paginator.$property( propertyName = "settings", mock = settings );
-                    var mockResults = [ { "getId": function() { return 1; } }, { "getId": function() { return 2; } }, { "getId": function() { return 3; } } ];
-                    var result = paginator.generateWithResults( 100, mockResults, 3, 25, true );
-                    expect( result.pagination ).toBe( {
-                        "maxRows": 25,
-                        "offset": 50,
-                        "page": 3,
-                        "totalPages": 4,
-                        "totalRecords": 100
-                    } );
-                    expect( result.results ).toBe( [ 1, 2, 3 ] );
                 } );
             } );
 		} );


### PR DESCRIPTION
This will be used by qb to avoid calling `count` when paginating (where needed)