### PR TITLE
Force Pagination Struct to Output Integers

### DIFF
--- a/models/Pagination.cfc
+++ b/models/Pagination.cfc
@@ -18,11 +18,11 @@ component singleton accessors="true" {
         numeric maxRows = 25
     ) {
         var pagination = {};
-        pagination[ "totalRecords" ] = arguments.totalRecords;
-        pagination[ "maxRows" ] = max( 0, arguments.maxRows );
-        pagination[ "totalPages" ] = pagination.maxRows != 0 ? ceiling( pagination.totalRecords / pagination.maxRows ) : 0;
-        pagination[ "page" ] = clamp( 1, arguments.page, pagination.totalPages );
-        pagination[ "offset" ] = ( pagination.page - 1 ) * pagination.maxRows;
+        pagination[ "totalRecords" ] = int( arguments.totalRecords );
+        pagination[ "maxRows" ] = int( max( 0, arguments.maxRows ) );
+        pagination[ "totalPages" ] = int( pagination.maxRows != 0 ? ceiling( pagination.totalRecords / pagination.maxRows ) : 0 );
+        pagination[ "page" ] = int( clamp( 1, arguments.page, pagination.totalPages ) );
+        pagination[ "offset" ] = int( ( pagination.page - 1 ) * pagination.maxRows );
         return pagination;
     }
 
@@ -78,9 +78,9 @@ component singleton accessors="true" {
         numeric maxRows = 25
     ) {
         var pagination = {};
-        pagination[ "maxRows" ] = max( 0, arguments.maxRows );
-        pagination[ "page" ] = arguments.page;
-        pagination[ "offset" ] = ( pagination.page - 1 ) * pagination.maxRows;
+        pagination[ "maxRows" ] = int( max( 0, arguments.maxRows ) );
+        pagination[ "page" ] = int( arguments.page );
+        pagination[ "offset" ] = int( ( pagination.page - 1 ) * pagination.maxRows );
         pagination[ "hasMore" ] = arguments.hasMore;
         return pagination;
     }


### PR DESCRIPTION
ACF has a nasty habit of converting integer data to decimals when serializing JSON unless the numbers are specifically typed as integers.  Forcing each key as `int()` eliminates any ambiguity and will please JSON purists or apps that require/expect an integer.

Before Change (ACF 2018+):
![image](https://user-images.githubusercontent.com/5341142/174391330-457261f2-c4c7-4b53-b388-34a1630d67f2.png)
Post Change (ACF 2018+)
![image](https://user-images.githubusercontent.com/5341142/174391412-18eb094a-af52-4e18-9633-a8360b595c1c.png)
